### PR TITLE
Bumped api version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/godbus/dbus/v5 v5.0.4-0.20200513180336-df5ef3eb7cca
 	github.com/shirou/gopsutil/v3 v3.21.9
-	github.com/unix-streamdeck/api v1.0.0
+	github.com/unix-streamdeck/api v1.0.1
 	github.com/unix-streamdeck/driver v0.0.0-20211119182210-fc6b90443bcd
 	golang.org/x/image v0.0.0-20201208152932-35266b937fa6 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a


### PR DESCRIPTION
Following the release of the API, this bumps the version number in `go.mod`.