### PR TITLE
Add Stream Deck MK.2 to example udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666", GROUP="plugdev"  
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666", GROUP="plugdev"  
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666", GROUP="plugdev"  
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0080", MODE:="666", GROUP="plugdev"  
 ```  
 
 - run `sudo udevadm control --reload-rules` to reload the udev rules


### PR DESCRIPTION
Just adds the correct example udev rule for the Stream Deck MK.2.

In response to #13 support was added for the Stream Deck MK.2, but the example udev rules were not updated to add the new product. This unfortunately means some people (i.e. me) might spend some time wondering why `streamdeckd` isn't connecting to their device even though they've set up the rules etc! :facepalm: 