### PR TITLE
Fix running commands on NixOS.

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func readConfig() (*api.Config, error) {
 
 func runCommand(command string) {
 	go func() {
-		cmd := exec.Command("/bin/sh", "-c", "/usr/bin/nohup "+command)
+		cmd := exec.Command("/bin/sh", "-c", "nohup "+command)
 
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			Setpgid:   true,


### PR DESCRIPTION
Resolves #22 

As mentioned in the issue, `nohup` does not exist at the path `/usr/bin/nohup` on NixOS, but like any Linux distro I can think of, it is a core utility that is available on the default `PATH`.